### PR TITLE
Fixed database-related issues

### DIFF
--- a/fitnick/heart_rate/models.py
+++ b/fitnick/heart_rate/models.py
@@ -25,6 +25,7 @@ heart_daily_table = Table(
     Column('minutes', Numeric(10, 5)),
     Column('date', Date, nullable=False),
     Column('calories', Numeric(10, 5)),
+    Column('resting_heart_rate', Integer()),
     UniqueConstraint('type', 'minutes', 'date', 'calories', name='daily_type_minutes_date_calories'),
     schema='heart',
 )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -37,8 +37,7 @@ def test_check_for_duplicates():
         'base_date': date.today().strftime('2020-09-02'),
         'period': '1d',
         'database': 'fitbit_test'}
-    ).insert_heart_rate_time_series_data(raise_exception=False)
-    # For the purpose of this test, we're not concerned with duplicates.
+    ).insert_heart_rate_time_series_data(connection=db_connection.connect())
 
     results = db_connection.execute(
         heart_daily_table.select().where(heart_daily_table.columns.date ==

--- a/tests/test_heart_rate.py
+++ b/tests/test_heart_rate.py
@@ -21,6 +21,17 @@ EXPECTED_ROWS = [
     ('Peak', Decimal('0.00000'), datetime.date(2020, 9, 5), Decimal('0.00000'), 68)
 ]
 
+EXPECTED_PERIOD_ROWS = [
+    ('Out of Range', Decimal('1267.00000'), datetime.date(2020, 9, 5), Decimal('2086.83184'), 68),
+    ('Fat Burn', Decimal('115.00000'), datetime.date(2020, 9, 5), Decimal('721.58848'), 68),
+    ('Cardio', Decimal('3.00000'), datetime.date(2020, 9, 5), Decimal('30.91792'), 68),
+    ('Peak', Decimal('0.00000'), datetime.date(2020, 9, 5), Decimal('0.00000'), 68),
+    ('Out of Range', Decimal('1210.00000'), datetime.date(2020, 9, 6), Decimal('1971.59232'), 69),
+    ('Fat Burn', Decimal('178.00000'), datetime.date(2020, 9, 6), Decimal('952.70632'), 69),
+    ('Cardio', Decimal('2.00000'), datetime.date(2020, 9, 6), Decimal('24.27440'), 69),
+    ('Peak', Decimal('0.00000'), datetime.date(2020, 9, 6), Decimal('0.00000'), 69)
+]
+
 EXPECTED_DATA = {'activities-heart': [
     {'dateTime': '2020-09-05', 'value': {'customHeartRateZones': [], 'heartRateZones': [
         {'caloriesOut': 2086.83184, 'max': 96, 'min': 30, 'minutes': 1267, 'name': 'Out of Range'},
@@ -52,18 +63,18 @@ def test_get_heart_rate_time_series_period():
         'database': 'fitbit_test',
         'base_date': '2020-09-05',
         'period': '1d'}
-    ).insert_heart_rate_time_series_data()
+    ).insert_heart_rate_time_series_data(db_connection)
 
     rows = [row for row in db_connection.execute('select * from heart.daily')]
 
-    assert rows == EXPECTED_ROWS
+    assert rows == EXPECTED_PERIOD_ROWS
 
 
 def test_query_heart_rate_zone_time_series():
     data = HeartRateZone(config={
         'database': 'fitbit_test',
         'base_date': '2020-09-05',
-        'period': '1d'}
+        'end_date': '2020-09-05'}
     ).query_heart_rate_zone_time_series()
 
     assert data == EXPECTED_DATA
@@ -73,7 +84,7 @@ def test_parse_response():
     rows = HeartRateZone(config={
         'database': 'fitbit_test',
         'base_date': '2020-09-05',
-        'period': '1d'}
+        'period': '2020-09-05'}
     ).parse_response(EXPECTED_DATA)
 
     for index, row in enumerate(rows):


### PR DESCRIPTION
Because of the way a few date-related methods were structured, several 1d requests were being made for backfills instead of one base_date - end_date request - which could achieve the same data with much more speed & efficiency. Also, somehow I didn't include resting_heart_rate in the heart_daily model. This PR fixes those issues & updates tests accordingly.