### PR TITLE
Fix calorie gathering

### DIFF
--- a/fitnick/activity/activity.py
+++ b/fitnick/activity/activity.py
@@ -93,10 +93,10 @@ class Activity:
         )
 
         update_statement = insert_statement.on_conflict_do_update(
-            constraint='date',
+            index_elements=['date'],
             set_={
-                'date': parsed_row.type,
-                'total': parsed_row.minutes,
+                'date': parsed_row.date,
+                'total': parsed_row.total,
                 'calories_bmr': parsed_row.calories_bmr,
                 'activity_calories': parsed_row.activity_calories
             })

--- a/fitnick/activity/activity.py
+++ b/fitnick/activity/activity.py
@@ -44,6 +44,18 @@ class Activity:
 
         return rows
 
+    def query_calorie_summary(self):
+        return self.query_daily_activity_summary()['summary']
+
+    @staticmethod
+    def parse_calorie_summary(date, response):
+        row = Calories(
+            date=date, total=response['caloriesOut'], calories_bmr=response['caloriesBMR'],
+            activity_calories=response['activityCalories']
+        )
+
+        return row
+
     @staticmethod
     def insert_log_data(database, parsed_rows):
         session = sessionmaker(bind=database.engine)()
@@ -68,18 +80,6 @@ class Activity:
                 continue
 
         return parsed_rows
-
-    def query_calorie_summary(self):
-        return self.query_daily_activity_summary()['summary']
-
-    @staticmethod
-    def parse_calorie_summary(date, response):
-        row = Calories(
-            date=date, total=response['caloriesOut'], calories_bmr=response['caloriesBMR'],
-            activity_calories=response['activityCalories']
-        )
-
-        return row
 
     @staticmethod
     def insert_calorie_data(database, parsed_row):

--- a/fitnick/activity/get_activity_calories.py
+++ b/fitnick/activity/get_activity_calories.py
@@ -1,0 +1,25 @@
+from fitnick.activity.activity import Activity
+from fitnick.database.database import Database
+
+
+def gather_calories_for_day(day='2020-10-22'):
+    activity = Activity(
+        config={
+            'database': 'fitbit',
+            'base_date': day
+        }
+    )
+    raw_calorie_summary = activity.query_calorie_summary()
+    row = activity.parse_calorie_summary(activity.config['base_date'], raw_calorie_summary)
+    database = Database('fitbit', 'schema')
+    activity.insert_calorie_data(database, row)
+
+    return
+
+
+def main():
+    gather_calories_for_day()
+
+
+if __name__ == '__main__':
+    main()

--- a/fitnick/activity/models/calories.py
+++ b/fitnick/activity/models/calories.py
@@ -14,6 +14,13 @@ class Calories(Base):
     UniqueConstraint('date', name='date')
     schema = 'activity'
 
+    def __eq__(self, other):
+        return self.date, self.total, self.calories_bmr == other.date, other.total, other.calories_bmr
+
+    def __str__(self):
+        return f"{self.date}, {self.total}, {self.calories_bmr}, {self.activity_calories}"
+
+
 
 calories_table = Table(
     'calories',

--- a/fitnick/body/models/weight.py
+++ b/fitnick/body/models/weight.py
@@ -12,6 +12,13 @@ class WeightRecord(Base):
     UniqueConstraint('date', name='date')
     schema = 'weight'
 
+    def __eq__(self, other):
+        return self.date, self.pounds == other.date, other.pounds
+
+    def __str__(self):
+        return f"{self.date}, {self.pounds}"
+
+
 
 weight_table = Table(
     'daily',

--- a/fitnick/heart_rate/models.py
+++ b/fitnick/heart_rate/models.py
@@ -17,6 +17,12 @@ class HeartDaily(Base):
     UniqueConstraint('type', 'minutes', 'date', 'calories', name='daily_type_minutes_date_calories')
     schema = 'heart'
 
+    def __eq__(self, other):
+        return self.date, self.minutes == other.date, other.minutes
+
+    def __str__(self):
+        return f"{self.date}, {self.type}, {self.calories}"
+
 
 heart_daily_table = Table(
     'daily',
@@ -41,6 +47,9 @@ class HeartIntraday(Base):
 
     def __str__(self):
         return f"{self.date}, {self.time}, {self.value}"
+
+    def __eq__(self, other):
+        return self.date, self.time == other.date, other.time
 
 
 heart_intraday_table = Table(

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -106,4 +106,6 @@ def test_insert_calorie_data():
     )
     raw_data = activity.query_calorie_summary()
     row = activity.parse_calorie_summary('2020-10-01', raw_data)
-    activity.insert_calorie_data(database, row)
+    inserted_row = activity.insert_calorie_data(database, row)
+
+    assert inserted_row == Calories(date='2020-10-01', total=3116, calories_bmr=1838, activity_calories=1467)

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -106,8 +106,4 @@ def test_insert_calorie_data():
     )
     raw_data = activity.query_calorie_summary()
     row = activity.parse_calorie_summary('2020-10-01', raw_data)
-
-    assert row.date == '2020-10-01'
-    assert row.total == 3116
-    assert row.calories_bmr == 1838
-    assert row.activity_calories == 1467
+    activity.insert_calorie_data(database, row)


### PR DESCRIPTION
- fixed insert/update for calories
- fixed test for insert calorie data.
- added parse/query calorie summary data methods
- added simple script for gathering activity calories for a given day

The previous source I was using for calorie data (heart rate zones) doesn't provide a total accounting of calories burned per day - this PR adds new methods that do, using the /activity/ endpoints from the API.